### PR TITLE
docs: registrar contrato conceptual del proyecto

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,127 @@
+# Abstractify
+
+Abstractify is a platform for creating and evolving digital textile stores through visual and conversational interaction while preserving a controlled commerce model.
+
+## People
+
+**Textile entrepreneur**:
+The person who creates, manages, and exports a store in Abstractify for a business that sells ready-made garments.
+_Avoid_: Customer, shopper, end user
+
+**Shopper**:
+The person who browses and purchases garments from a generated store.
+_Avoid_: Textile entrepreneur, platform user
+
+## Store design
+
+**Store project**:
+The persistent representation of one textile business and its digital store inside Abstractify, owned and edited by one textile entrepreneur without collaborative editing.
+_Avoid_: Website, generated code
+
+**Project document**:
+The complete, structured composition of a store project at one point in its history, including pages, component instances, theme, bindings, interactions, and asset references.
+_Avoid_: JSX, generated code, database catalog
+
+**Canvas**:
+The visual workspace where the textile entrepreneur composes and refines the presentation of a store project.
+_Avoid_: Preview, generated store
+
+**Store page**:
+A routed composition of registered components within a store project; commerce pages are required while content pages may be added by the textile entrepreneur.
+_Avoid_: Window, canvas
+
+**Component instance**:
+One identified occurrence of a registered component in a project document, with its own properties, styles, bindings, interactions, and named slots.
+_Avoid_: DOM element, JSX fragment
+
+**Component slot**:
+A named containment role through which a component instance accepts compatible child components.
+_Avoid_: Arbitrary child array, DOM position
+
+**Component registry**:
+The comprehensive, versioned catalog of verified structural, content, navigation, commerce, form, and state components available within the approved textile-store domain.
+_Avoid_: Generated JSX, arbitrary package, first-version subset
+
+**Project block**:
+A reusable, versioned composition of registered components owned by one store project; an instance may remain linked to the block or be explicitly detached.
+_Avoid_: Custom code, global template
+
+**Theme**:
+The project-wide visual language whose values are inherited by pages and component instances and may be overridden through validated styles.
+_Avoid_: Abstractify application theme, template
+
+**Catalog binding**:
+A declarative connection between a component instance and products, categories, collections, search results, or current commerce context.
+_Avoid_: Embedded product copy, SQL query, script
+
+**Project asset**:
+Verified media owned by the textile entrepreneur and referenced by a store project through a stable identity.
+_Avoid_: Arbitrary external URL, local file path
+
+## Change and history
+
+**Project operation**:
+A validated semantic modification to a store project, regardless of whether it originated from the canvas, text, or voice.
+_Avoid_: DOM mutation, source-code edit
+
+**Operation batch**:
+An atomic collection of project operations representing one complete user intention.
+_Avoid_: Partial proposal, keystroke history
+
+**Pending operation**:
+A semantic manual modification retained locally until Abstractify confirms that it belongs to an accepted revision.
+_Avoid_: Assistant proposal, unsaved canvas
+
+**Assistant proposal**:
+An atomic candidate operation batch derived from a spoken or written instruction that has not changed the accepted store project.
+_Avoid_: Applied change, generated code
+
+**Accepted revision**:
+An immutable project document created after a valid manual operation batch, accepted assistant proposal, import, or migration.
+_Avoid_: Draft, preview, mutable snapshot
+
+**Project migration**:
+A validated transformation that creates a new accepted revision compatible with newer project or component-registry rules while preserving historical revisions.
+_Avoid_: In-place rewrite, automatic downgrade
+
+**Validation level**:
+The verified usability reached by an accepted revision: editable, previewable, or exportable.
+_Avoid_: Draft status, publication state
+
+**Voice instruction**:
+An editable transcription of spoken input that enters the same assistant flow as a written instruction.
+_Avoid_: Voice command execution, audio operation
+
+## Commerce and export
+
+**Ready-made inventory**:
+A finite set of completed garments available for immediate sale; it excludes manufacturing and made-to-order production.
+_Avoid_: Production plan, raw materials
+
+**Textile product**:
+A garment offered by a store with shared commercial identity, description, presentation, and pricing.
+_Avoid_: Sellable variant, component
+
+**Sellable variant**:
+A purchasable form of a textile product identified by its commercial attributes, such as size and color, and its own SKU and stock.
+_Avoid_: Size, textile product
+
+**Verified template**:
+An approved, versioned full-stack store foundation whose expected behavior, build, tests, and reproducibility have been established before it is offered to textile entrepreneurs.
+_Avoid_: Assistant proposal, visual theme
+
+**Generated store**:
+The independent digital commerce application produced from one exportable accepted revision and a frozen catalog snapshot.
+_Avoid_: Canvas, preview
+
+**Store administration**:
+The private area of a generated store where its textile entrepreneur manages products, sellable variants, inventory, and order status after deployment.
+_Avoid_: Abstractify canvas, storefront
+
+**Payment gateway**:
+Mercado Pago as the verified payment service configured independently for each generated store.
+_Avoid_: Yape, Plin, simulated payment
+
+**Store export**:
+The self-contained, reproducible deliverable generated from explicitly frozen project, registry, template, catalog, and generator identities.
+_Avoid_: Source snippet, preview, latest project state

--- a/docs/adr/0001-structured-project-document.md
+++ b/docs/adr/0001-structured-project-document.md
@@ -1,0 +1,18 @@
+# Structured project document as the canonical store state
+
+Abstractify will represent each accepted store state as an immutable, versioned project document composed only from verified registry components, typed content and catalog bindings, scoped parsed CSS, declarative interactions, and owned asset references. Catalog and transactional commerce data remain relational; manual edits and accepted assistant proposals use the same atomic operation vocabulary; JSX, JavaScript, runtime code, and legacy snapshots are never canonical state. This choice preserves unrestricted composition and styling within the approved textile-commerce domain while making validation, history, preview, migration, and deterministic full-stack export reproducible.
+
+## Considered Options
+
+- Arbitrary JSX snapshots were rejected because they combine data and executable code, cannot be validated semantically, and currently diverge between editor, persistence, and export.
+- Fully normalized visual-node tables were rejected because they make the evolving visual document expensive to reconstruct and migrate without improving commerce ownership.
+- A structured project document plus separate relational commerce data was selected because it keeps one portable design aggregate while preserving strong catalog, inventory, order, and payment invariants.
+
+## Consequences
+
+- The component registry must comprehensively cover the approved textile-store domain and remain immutable per published version.
+- Free CSS is parsed into a scoped canonical representation; arbitrary JavaScript, HTML, packages, and external imports remain prohibited.
+- Every accepted change stores a complete canonical document, its atomic operation batch, lineage, versions, actor, and reproducible hash.
+- Concurrent operations from the single owner reapply automatically at node/property granularity; a missing structural target is reported and never silently recreated.
+- The exporter pins the accepted revision, registry, verified template, catalog snapshot, assets, and generator so equal frozen inputs yield equal artifacts.
+- Existing disposable JSX data is not preserved; useful designs are rebuilt from verified components before operational migration begins.


### PR DESCRIPTION
## Decisión registrada
- define el vocabulario común de proyecto, documento, páginas, nodos, bloques, operaciones, revisiones, assets y exportación
- registra el documento estructurado y versionado como estado canónico
- conserva catálogo e inventario como dominio relacional separado
- permite composición completa y CSS libre parseado/aislado
- elimina JSX arbitrario como fuente de verdad
- fija revisiones inmutables y exportaciones reproducibles

## Verificación
- decisión confirmada tras el grilling de TP1202510051/back-end#45
- CONTEXT.md respeta el formato de glosario y no contiene especificación ejecutable
- ADR registra alternativas y consecuencias
- archivos idénticos al PR correspondiente del backend
- git diff --check: OK

No inicia `/to-spec` ni implementación y no modifica `main`.